### PR TITLE
Add Machete order

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 `StarWarsArrays.jl` is a [Julia](https://julialang.org/) package to provide
 arrays indexed as the order of the Star Wars movies.  Thus, index 4 points to
 the first element of the parent array, index 2 points to its fifth element, and
-index 9 points to the nineth element.
+index 9 points to the nineth element.  The ordering applies to all dimensions of
+the array.  `StarWarsArrays.jl` also supports [Machete
+Order](https://www.nomachetejuggling.com/2011/11/11/the-star-wars-saga-suggested-viewing-order/).
 
 This package is inspired by the Reddit thread ["Oof level of an array,
 nice."](https://www.reddit.com/r/ProgrammerHumor/comments/clna6k/oof_level_of_an_array_nice/).
@@ -32,7 +34,7 @@ pkg> add https://github.com/giordano/StarWarsArrays
 julia> using StarWarsArrays
 
 julia> v = StarWarsArray(collect(1:9))
-9-element StarWarsArray{Int64,1,Array{Int64,1}}:
+9-element StarWarsArray{Int64,1,Array{Int64,1},StarWarsArrays.OriginalOrder}:
  4
  5
  6
@@ -56,7 +58,7 @@ julia> v[5] = 42
 42
 
 julia> v
-9-element StarWarsArray{Int64,1,Array{Int64,1}}:
+9-element StarWarsArray{Int64,1,Array{Int64,1},StarWarsArrays.OriginalOrder}:
   4
   5
   6
@@ -68,7 +70,7 @@ julia> v
   9
 
 julia> m = StarWarsArray(reshape(collect(1:81), 9, 9))
-9×9 StarWarsArray{Int64,2,Array{Int64,2}}:
+9×9 StarWarsArray{Int64,2,Array{Int64,2},StarWarsArrays.OriginalOrder}:
  31  40  49  4  13  22  58  67  76
  32  41  50  5  14  23  59  68  77
  33  42  51  6  15  24  60  69  78
@@ -95,7 +97,7 @@ julia> m[3,2] = -1
 -1
 
 julia> m
-9×9 StarWarsArray{Int64,2,Array{Int64,2}}:
+9×9 StarWarsArray{Int64,2,Array{Int64,2},StarWarsArrays.OriginalOrder}:
  31  40  49  4  13  22  58  67  76
  32  41  50  5  14  23  59  68  77
  33  -1  51  6  15  24  60  69  78
@@ -105,6 +107,55 @@ julia> m
  34  43  52  7  16  25  61  70  79
  35  44  53  8  17  26  62  71  80
  36  45  54  9  18  27  63  72  81
+```
+
+The second of `StarWarsArray` allows you to specify the order.  Here is how to
+use `MacheteOrder`:
+
+```julia
+julia> using StarWarsArrays
+
+julia> v = StarWarsArray(collect(1:9), MacheteOrder)
+8-element view(::Array{Int64,1}, [3, 4, 1, 2, 5, 6, 7, 8]) with eltype Int64:
+ 3
+ 4
+ 1
+ 2
+ 5
+ 6
+ 7
+ 8
+
+julia> v[4]
+1
+
+julia> v[3]
+4
+
+julia> v[1]
+ERROR: StarWarsError: there is no episode 1 in order MacheteOrder
+[...]
+
+julia> m = StarWarsArray(reshape(collect(1:81), 9, 9), MacheteOrder)
+8×8 view(::Array{Int64,2}, [3, 4, 1, 2, 5, 6, 7, 8], [3, 4, 1, 2, 5, 6, 7, 8]) with eltype Int64:
+ 21  30  3  12  39  48  57  66
+ 22  31  4  13  40  49  58  67
+ 19  28  1  10  37  46  55  64
+ 20  29  2  11  38  47  56  65
+ 23  32  5  14  41  50  59  68
+ 24  33  6  15  42  51  60  69
+ 25  34  7  16  43  52  61  70
+ 26  35  8  17  44  53  62  71
+
+julia> m[5,4]
+2
+
+julia> m[2,9]
+66
+
+julia> m[1,6]
+ERROR: StarWarsError: there is no episode 1 in MacheteOrder
+[...]
 ```
 
 ## License

--- a/src/StarWarsArrays.jl
+++ b/src/StarWarsArrays.jl
@@ -1,14 +1,39 @@
 module StarWarsArrays
 
-export StarWarsArray
+export StarWarsArray, OriginalOrder, MacheteOrder
 
-struct StarWarsArray{T,N,P<:AbstractArray} <: AbstractArray{T,N}
+# Orders
+abstract type StarWarsOrder end
+struct OriginalOrder <: StarWarsOrder end
+struct MacheteOrder <: StarWarsOrder end
+
+# Exception
+struct StarWarsError <: Exception
+    i::Any
+    order::Any
+end
+
+function Base.showerror(io::IO, err::StarWarsError)
+    print(io, "StarWarsError: there is no episode $(err.i) in $(err.order)")
+end
+
+# The main struct
+struct StarWarsArray{T,N,P<:AbstractArray,O<:StarWarsOrder} <: AbstractArray{T,N}
     parent::P
 end
-StarWarsArray(p::P) where {T,N,P<:AbstractArray{T,N}} =
-    StarWarsArray{T,N,P}(p)
+function StarWarsArray(p::P, order::Type{<:StarWarsOrder}=OriginalOrder) where {T,N,P<:AbstractArray{T,N}}
+    StarWarsArray{T,N,P,order}(p)
+end
 
-function index(i::Int)
+machete_view_index(i) = range(1, stop=i)
+function StarWarsArray(p::P, order::Type{MacheteOrder}) where {T,N,P<:AbstractArray{T,N}}
+    StarWarsArray{T,N,P,order}(view(p, machete_view_index.(size(p) .- 1)...))
+end
+
+order(::StarWarsArray{T,N,P,O}) where {T,N,P,O} = O
+
+# Indexing
+function index(i::Int, ::Int, ::Type{OriginalOrder})
     if 4 <= i <= 6
         return i - 3
     elseif 1 <= i <= 3
@@ -17,14 +42,41 @@ function index(i::Int)
         return i
     end
 end
+function index(i::Int, size::Int, order::Type{MacheteOrder})
+    if 4 <= i <= 5
+        return i - 3
+    elseif 2 <= i <= 3
+        return i + 1
+    elseif  6 <= i <= size + 1
+        return i - 1
+    elseif i == 1
+        throw(StarWarsError(i,order))
+    else
+        return i
+    end
+end
 
+# Get the parent
 Base.parent(A::StarWarsArray) = A.parent
-Base.size(A::StarWarsArray) = size(parent(A))
-Base.getindex(A::StarWarsArray, i::Int) = getindex(parent(A), index(i))
+
+# Get the size
+Base.size(A::StarWarsArray{T,N,P,O}) where {T,N,P,O} = size(parent(A))
+
+# Get the elements
+Base.getindex(A::StarWarsArray, i::Int) =
+    getindex(parent(A), index(i, length(parent(A)), order(A)))
 Base.getindex(A::StarWarsArray{T,N}, i::Vararg{Int,N}) where {T,N} =
-    getindex(parent(A), index.(i)...)
-Base.setindex!(A::StarWarsArray, v, i::Int) = setindex!(parent(A), v, index(i))
+    getindex(parent(A), index.(i, size(parent(A)), order(A))...)
+Base.setindex!(A::StarWarsArray, v, i::Int) =
+    setindex!(parent(A), v, index(i, length(parent(A)), order(A)))
 Base.setindex!(A::StarWarsArray{T,N}, v, i::Vararg{Int,N}) where {T,N} =
-    setindex!(parent(A), v, index.(i)...)
+    setindex!(parent(A), v, index.(i, size(parent(A)), order(A))...)
+
+# Showing.  Note: this is awful, but it does what I want
+Base.show(io::IO, m::MIME"text/plain", A::StarWarsArray{T,N,P,MacheteOrder}) where {T,N,P} =
+    show(io, m,
+         view(parent(A),
+              map(i->StarWarsArrays.index.(i .+ 1, length(A), MacheteOrder),
+                  StarWarsArrays.machete_view_index.(size(A)))...))
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,11 @@
 using StarWarsArrays
 using Test
 
-@testset "StarWarsArrays.jl" begin
+import StarWarsArrays: StarWarsError, order
+
+@testset "OriginalOrder" begin
     v = StarWarsArray(collect(1:9))
+    @test order(v) == OriginalOrder
     @test size(v) == size(parent(v))
     @test v[5] == 2
     @test v[3] == 6
@@ -11,7 +14,8 @@ using Test
     v[4] = -42
     @test v[4] == -42
 
-    m = StarWarsArray(reshape(collect(1:81), 9, 9))
+    m = StarWarsArray(reshape(collect(1:81), 9, 9), OriginalOrder)
+    @test order(m) == OriginalOrder
     @test size(m) == size(parent(m))
     @test m[5] == 2
     @test m[3,4] == 6
@@ -22,4 +26,41 @@ using Test
     @test m[4] == -42
     m[1] = 0
     @test m[1,4] == 0
+end
+
+@testset "MacheteOrder" begin
+    v = StarWarsArray(collect(1:9), MacheteOrder)
+    @test order(v) == MacheteOrder
+    @test size(v) == (8,)
+    @test v[5] == 2
+    @test v[3] == 4
+    @test v[6] == 5
+    @test v[7] == 6
+    @test_throws StarWarsError v[1]
+    @test_throws BoundsError v[0]
+    v[4] = -42
+    @test v[4] == -42
+
+    m = StarWarsArray(reshape(collect(1:81), 9, 9), MacheteOrder)
+    @test order(m) == MacheteOrder
+    @test size(m) == (8, 8)
+    @test m[5] == 2
+    @test m[3,4] == 4
+    @test m[7,2] == 24
+    @test m[4,4] == 1
+    @test m[9,4] == 8
+    @test_throws BoundsError m[0, 12]
+    @test_throws BoundsError m[82]
+    @test_throws StarWarsError m[1]
+    @test_throws StarWarsError m[3, 1]
+    rpr = split(repr("text/plain", m), '\n')
+    @test rpr[2] == " 21  30  3  12  39  48  57  66"
+    @test rpr[6] == " 23  32  5  14  41  50  59  68"
+    m[4,4] = -42
+    @test m[4] == -42
+    m[2] = 0
+    @test m[2,4] == 0
+
+    @test sprint(showerror, StarWarsArrays.StarWarsError(1, MacheteOrder)) ==
+        "StarWarsError: there is no episode 1 in MacheteOrder"
 end


### PR DESCRIPTION
It took me a while to implement this because I didn't know whether I want to cut out the first or the last element in each dimension.  In the end I decided to go with the last one, so that
```julia
julia> v = StarWarsArray(collect(1:9), MacheteOrder)
8-element view(::Array{Int64,1}, [3, 4, 1, 2, 5, 6, 7, 8]) with eltype Int64:
 3
 4
 1
 2
 5
 6
 7
 8
```
gives the view order.

Also, `show`ing the array was a bit of a mess because `show` insists on displaying the first element, I ended up showing a `view` of the parent.  Probably there is something better to do this.