### PR TITLE
Don't subtype AbstractArray

### DIFF
--- a/src/StarWarsArrays.jl
+++ b/src/StarWarsArrays.jl
@@ -18,7 +18,7 @@ function Base.showerror(io::IO, err::StarWarsError)
 end
 
 # The main struct
-struct StarWarsArray{T,N,P<:AbstractArray,O<:StarWarsOrder} <: AbstractArray{T,N}
+struct StarWarsArray{T,N,P<:AbstractArray,O<:StarWarsOrder}
     parent::P
 end
 function StarWarsArray(p::P, order::Type{<:StarWarsOrder}=OriginalOrder) where {T,N,P<:AbstractArray{T,N}}


### PR DESCRIPTION
AbstractArray axes are supposed to be `AbstractUnitRange` and `StarWarsArray` doesn't have that property. People like to use StarWarsArrays.jl as an example of how flexible AbstractArray is but I think it can be misleading in this way.