### PR TITLE
Make StarWarsArrays AbstractArray interface compliant

### DIFF
--- a/src/StarWarsArrays.jl
+++ b/src/StarWarsArrays.jl
@@ -78,12 +78,16 @@ Base.setindex!(A::StarWarsArray, v, i::Int) =
 Base.setindex!(A::StarWarsArray{T,N}, v, i::Vararg{Int,N}) where {T,N} =
     setindex!(parent(A), v, index.(i, size(parent(A)), order(A))...)
 
-# Axes
-Base.axes(A::StarWarsArray{T,N,P,OriginalOrder}) where {T,N,P} =
+# StarWarsArrays.axes
+axes(A::StarWarsArray{T,N,P,OriginalOrder}) where {T,N,P} =
     map(i->index.(i, length(A), order(A)), machete_view_index.(size(A)))
 
-Base.axes(A::StarWarsArray{T,N,P,MacheteOrder}) where {T,N,P} =
+axes(A::StarWarsArray{T,N,P,MacheteOrder}) where {T,N,P} =
     map(i->index.(i .+ 1, length(A), MacheteOrder), machete_view_index.(size(A)))
+
+# StarWarsArrays.eachindex
+eachindex(A::StarWarsArray{<: Any,1}) = first(axes(A))
+eachindex(A::StarWarsArray) = vec(LinearIndices(size(A))[axes(A)...])
 
 # Iteration
 function iterate_revindex(i::Int, ::Type{OriginalOrder})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,8 +15,10 @@ import StarWarsArrays: StarWarsError, order
         " 4\n 5\n 6\n 1\n 2\n 3\n 7\n 8\n 9"
     v[4] = -42
     @test v[4] == -42
-    @test axes(v) == ([4, 5, 6, 1, 2, 3, 7, 8, 9],)
-    @test eachindex(v) == [4, 5, 6, 1, 2, 3, 7, 8, 9]
+    @test StarWarsArrays.axes(v) == ([4, 5, 6, 1, 2, 3, 7, 8, 9],)
+    @test StarWarsArrays.eachindex(v) == [4, 5, 6, 1, 2, 3, 7, 8, 9]
+    @test axes(v) === (Base.OneTo(length(v)),)
+    @test eachindex(v) === Base.OneTo(length(v))
     @test length(v) == 9
     @test size(v) == (9,)
     for (idx, x) in enumerate(v)
@@ -39,7 +41,8 @@ import StarWarsArrays: StarWarsError, order
     @test m[4] == -42
     m[1] = 0
     @test m[1,4] == 0
-    @test axes(m) == ([4, 5, 6, 1, 2, 3, 7, 8, 9], [4, 5, 6, 1, 2, 3, 7, 8, 9])
+    @test StarWarsArrays.axes(m) == ([4, 5, 6, 1, 2, 3, 7, 8, 9], [4, 5, 6, 1, 2, 3, 7, 8, 9])
+    @test axes(m) == (Base.OneTo(size(m,1)), Base.OneTo(size(m,2)))
     @test length(m) == 81
     @test size(m) == (9, 9)
     for (idx, x) in enumerate(m)
@@ -64,8 +67,10 @@ end
         " 3\n 4\n 1\n 2\n 5\n 6\n 7\n 8"
     v[4] = -42
     @test v[4] == -42
-    @test axes(v) == ([3, 4, 1, 2, 5, 6, 7, 8],)
-    @test eachindex(v) == [3, 4, 1, 2, 5, 6, 7, 8]
+    @test StarWarsArrays.axes(v) == ([3, 4, 1, 2, 5, 6, 7, 8],)
+    @test StarWarsArrays.eachindex(v) == [3, 4, 1, 2, 5, 6, 7, 8]
+    @test axes(v) == (Base.OneTo(length(v)),)
+    @test eachindex(v) == Base.OneTo(length(v))
     @test length(v) == 8
     @test size(v) == (8,)
     for (idx, x) in enumerate(v)
@@ -91,7 +96,8 @@ end
     @test m[4] == -42
     m[2] = 0
     @test m[2,4] == 0
-    @test axes(m) == ([3, 4, 1, 2, 5, 6, 7, 8], [3, 4, 1, 2, 5, 6, 7, 8])
+    @test StarWarsArrays.axes(m) == ([3, 4, 1, 2, 5, 6, 7, 8], [3, 4, 1, 2, 5, 6, 7, 8])
+    @test axes(m) == (Base.OneTo(size(m,1)), Base.OneTo(size(m,2)))
     @test length(m) == 64
     @test size(m) == (8, 8)
     for (idx, x) in enumerate(m)


### PR DESCRIPTION
> `axes(A)` [should](https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-array) "Return a tuple of `AbstractUnitRange{<:Integer}`
of valid indices. The axes should be their own axes, that is
`axes.(axes(A),1) == axes(A)` should be satisfied."

Instead create a `StarWarsArrays.axes` and `StarWarsArrays.eachindex`
